### PR TITLE
Fix: Pin transitive dependencies to resolve Streamlit Cloud installat…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,5 +11,9 @@ scipy>=1.10.0
 scikit-image>=0.20.0
 pytest>=7.3.1
 setuptools>=65.5.0
+rich==14.0.0
+markdown-it-py==3.0.0
+pygments==2.19.1
+mdurl==0.1.2
 # Old dependency that's no longer needed:
 # streamlit-pdf-viewer==0.0.3


### PR DESCRIPTION
…ion error

I've added explicit versions for rich, markdown-it-py, pygments, and mdurl in your requirements.txt. These packages were identified as causing installation issues on Streamlit Cloud, where pip was attempting to uninstall and reinstall the same versions, leading to an error.

Pinning these dependencies aims to stabilize the dependency resolution process on the Streamlit Cloud platform.

## Summary by Sourcery

Bug Fixes:
- Pin rich, markdown-it-py, pygments, and mdurl to specific versions to resolve installation errors on Streamlit Cloud.