### PR TITLE
Fix: Remove problematic deployment dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,10 +18,8 @@ coverage==7.8.0
 crashtest==0.4.1
 cryptography==41.0.7
 cycler==0.12.1
-dbus-python==1.3.2
 distlib==0.3.9
 distro==1.9.0
-distro-info==1.7+build1
 dulwich==0.22.8
 exceptiongroup==1.2.2
 fastjsonschema==2.21.1


### PR DESCRIPTION
This commit refines the requirements.txt file by removing `distro-info==1.7+build1` and `dbus-python==1.3.2`.

These packages were identified as causing deployment failures on Streamlit Cloud after a recent update of all dependencies to their latest versions.
- `distro-info==1.7+build1` caused a resolution error with the `uv` installer.
- `dbus-python==1.3.2` failed to build due to missing system dependencies (pkg-config and dbus-1) in the deployment environment.

I confirmed that removing these specific lines from the frozen requirements.txt allows the remaining (updated) dependencies to be installed successfully without pulling these problematic packages back in. This suggests they were transitive dependencies not strictly required by the core application packages.

This change aims to restore deployability while retaining the majority of the recent dependency updates.