### PR TITLE
Fix: Update pyarrow and resolve build issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,6 @@ findpython==0.6.3
 fonttools==4.58.0
 gitdb==4.0.12
 GitPython==3.1.44
-gyp==0.1
 h11==0.16.0
 httpcore==1.0.9
 httplib2==0.20.4


### PR DESCRIPTION
This commit addresses deployment failures by:
1. Removing `distro-info`, `dbus-python`, and `gyp` from requirements, as these were causing various build/resolution errors in the deployment environment after an initial attempt to update all dependencies.
2. Pinning `pyarrow` to version `20.0.0`. An earlier build error incorrectly suggested `pyarrow==2.0.0` was the issue; the environment actually has/needs `pyarrow==20.0.0`, which is now explicitly set.

These changes aim to create a stable `requirements.txt` that allows successful deployment on Streamlit Cloud while retaining most of the dependency updates from the "update-to-latest" effort.