### PR TITLE
Add basic GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: CI
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libgl1
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .[dev]
+      - name: Lint
+        run: |
+          black --check .
+          isort --check-only .
+          flake8 .
+      - name: Test
+        run: pytest -q


### PR DESCRIPTION
## Summary
- add minimal CI workflow for lint and test with Python 3.11

## Testing
- `black --check .` *(fails: would reformat)*
- `flake8 .` *(fails: E501 line too long)*
- `isort --check-only .` *(fails: incorrectly sorted imports)*
- `pytest -q` *(fails: 6 failed, 38 passed)*


------
https://chatgpt.com/codex/tasks/task_e_68410ff74ff4832792a77562f348bd24