### PR TITLE
Fix tests for streamlit app

### DIFF
--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -27,30 +27,30 @@ class TestApp(unittest.TestCase):
     def test_app_loads_without_errors(self):
         """Test that the app loads without exceptions."""
         at = AppTest.from_file("app.py")
-        at.run()
+        at.run(timeout=10)
         
         # Check that the app loaded successfully
-        self.assertIsNone(at.exception, f"App failed to load: {at.exception}")
+        self.assertFalse(at.exception, f"App failed to load: {at.exception}")
         
     @pytest.mark.slow
     def test_sidebar_elements_exist(self):
         """Test that expected sidebar elements are present."""
         at = AppTest.from_file("app.py")
-        at.run()
+        at.run(timeout=10)
         
         # Check sidebar exists
         self.assertIsNotNone(at.sidebar, "Sidebar should exist")
         
         # Check for title (more flexible check)
-        sidebar_content = str(at.sidebar)
-        self.assertIn("Multiphoton", sidebar_content.lower(), 
+        sidebar_title = at.sidebar.title[0].value
+        self.assertIn("multiphoton", sidebar_title.lower(),
                      "Sidebar should contain multiphoton-related content")
         
     @pytest.mark.slow
     def test_main_page_structure(self):
         """Test that the main page has expected structure."""
         at = AppTest.from_file("app.py")
-        at.run()
+        at.run(timeout=10)
         
         # Check that main content exists
         self.assertIsNotNone(at.main, "Main content should exist")
@@ -63,7 +63,7 @@ class TestApp(unittest.TestCase):
     def test_session_state_initialization(self):
         """Test that session state is properly initialized."""
         at = AppTest.from_file("app.py")
-        at.run()
+        at.run(timeout=10)
         
         # Check that key session state variables exist
         expected_keys = ["study_name", "wavelength", "researcher"]
@@ -81,10 +81,10 @@ class TestApp(unittest.TestCase):
         
         # Test with invalid session state
         at.session_state["wavelength"] = "invalid"
-        at.run()
+        at.run(timeout=10)
         
         # App should still run (error handling should prevent crashes)
-        self.assertIsNone(at.exception, "App should handle invalid input gracefully")
+        self.assertFalse(at.exception, "App should handle invalid input gracefully")
 
 @pytest.mark.skipif(not STREAMLIT_TESTING_AVAILABLE, 
                    reason="Streamlit testing framework not available")

--- a/tests/test_pdf_viewer.py
+++ b/tests/test_pdf_viewer.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 from unittest.mock import patch, MagicMock
 import streamlit as st
+import streamlit_pdf_viewer
 
 
 class TestPDFViewer:
@@ -25,17 +26,17 @@ class TestPDFViewer:
     def test_pdf_viewer_annotations_parameter(self):
         """Test that pdf_viewer can be called with annotations parameter."""
         try:
-            from streamlit_pdf_viewer import pdf_viewer
+            import streamlit_pdf_viewer
         except ImportError:
             pytest.skip("streamlit-pdf-viewer not installed")
-        
+
         # Test that calling pdf_viewer with annotations=[] doesn't raise TypeError
         with patch('streamlit_pdf_viewer.pdf_viewer') as mock_pdf_viewer:
             mock_pdf_viewer.return_value = None
-            
+
             # This should not raise "annotations must be a list of dictionaries" error
             try:
-                pdf_viewer(str(self.test_pdf_path), width=700, height=800, annotations=[])
+                streamlit_pdf_viewer.pdf_viewer(str(self.test_pdf_path), width=700, height=800, annotations=[])
                 mock_pdf_viewer.assert_called_once_with(
                     str(self.test_pdf_path), 
                     width=700, 
@@ -51,7 +52,7 @@ class TestPDFViewer:
     def test_pdf_viewer_invalid_annotations(self):
         """Test that pdf_viewer properly handles invalid annotations parameter."""
         try:
-            from streamlit_pdf_viewer import pdf_viewer
+            import streamlit_pdf_viewer
         except ImportError:
             pytest.skip("streamlit-pdf-viewer not installed")
         
@@ -61,12 +62,12 @@ class TestPDFViewer:
             mock_pdf_viewer.side_effect = TypeError("annotations must be a list of dictionaries")
             
             with pytest.raises(TypeError, match="annotations must be a list of dictionaries"):
-                pdf_viewer(str(self.test_pdf_path), width=700, height=800, annotations="invalid")
+                streamlit_pdf_viewer.pdf_viewer(str(self.test_pdf_path), width=700, height=800, annotations="invalid")
     
     def test_pdf_viewer_valid_annotations_format(self):
         """Test that pdf_viewer accepts properly formatted annotations."""
         try:
-            from streamlit_pdf_viewer import pdf_viewer
+            import streamlit_pdf_viewer
         except ImportError:
             pytest.skip("streamlit-pdf-viewer not installed")
         
@@ -78,8 +79,8 @@ class TestPDFViewer:
         
         with patch('streamlit_pdf_viewer.pdf_viewer') as mock_pdf_viewer:
             mock_pdf_viewer.return_value = None
-            
-            pdf_viewer(str(self.test_pdf_path), width=700, height=800, annotations=valid_annotations)
+
+            streamlit_pdf_viewer.pdf_viewer(str(self.test_pdf_path), width=700, height=800, annotations=valid_annotations)
             mock_pdf_viewer.assert_called_once_with(
                 str(self.test_pdf_path), 
                 width=700, 
@@ -100,7 +101,7 @@ class TestPDFViewer:
              patch('streamlit.text_area') as mock_text_area, \
              patch('streamlit.button') as mock_button, \
              patch('streamlit.download_button') as mock_download_button, \
-             patch('streamlit_pdf_viewer.pdf_viewer') as mock_pdf_viewer, \
+             patch('modules.measurements.pulse_and_fluorescence.pdf_viewer') as mock_pdf_viewer, \
              patch('builtins.open', create=True) as mock_open:
             
             # Set up mocks
@@ -131,7 +132,7 @@ class TestPDFViewer:
 def test_pdf_viewer_error_detection():
     """Standalone test function to detect PDF viewer annotation errors."""
     try:
-        from streamlit_pdf_viewer import pdf_viewer
+        import streamlit_pdf_viewer
         
         # Test path
         test_path = Path(__file__).parent.parent / "assets" / "s41596-024-01120-w.pdf"
@@ -142,7 +143,7 @@ def test_pdf_viewer_error_detection():
         # This should work without raising TypeError about annotations
         with patch('streamlit_pdf_viewer.pdf_viewer') as mock_viewer:
             mock_viewer.return_value = None
-            pdf_viewer(str(test_path), width=700, height=800, annotations=[])
+            streamlit_pdf_viewer.pdf_viewer(str(test_path), width=700, height=800, annotations=[])
             
         return True
         


### PR DESCRIPTION
## Summary
- prevent false positives for AppTest exceptions and increase timeout
- update sidebar title assertion
- mock PDF viewer correctly in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68411ad86fac8327a8fcacf0db9650a5

## Summary by Sourcery

Fix test suite for the Streamlit app by correcting PDF viewer imports and mocks, improving exception assertions, refining sidebar title checks, and increasing test timeouts.

Tests:
- Increase AppTest.run timeout to 10 seconds across all tests to prevent hangs
- Replace assertIsNone(at.exception) with assertFalse(at.exception) to avoid false positives
- Refine sidebar title assertion to check sidebar.title[0].value for correct content
- Standardize pdf_viewer imports to use streamlit_pdf_viewer.pdf_viewer and patch the actual module path in integration tests