### PR TITLE
Update dependencies and docs for Python compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The easiest way to get started is using the provided setup script:
 ```
 
 The script will:
-- Check Python version (3.8+ required, 3.10 recommended)
+ - Check Python version (3.8+ required, 3.10 recommended; 3.9.7 not supported)
 - Create a virtual environment
 - Install all dependencies
 - Launch the application
@@ -108,7 +108,7 @@ This application is optimized for Streamlit Community Cloud deployment:
 
 **Required files for Streamlit Cloud:**
 - `packages.txt` - System dependencies  
-- `runtime.txt` - Python version (3.10)
+ - `runtime.txt` - Python version (3.10; Python 3.9.7 is unsupported)
 
 **Note:** Streamlit Cloud requires a `requirements.txt` file. If needed, generate one from pyproject.toml:
 ```bash
@@ -132,7 +132,7 @@ Then visit http://localhost:8501
 
 ## System Requirements
 
-- **Python**: 3.8+ (3.10 recommended)
+- **Python**: 3.8+ (3.10 recommended; 3.9.7 not supported)
 - **System Dependencies** (auto-installed on Streamlit Cloud/Docker):
   - libgl1, libglib2.0-0, poppler-utils
   - libgtk2.0-0, libx11-xcb1, libnss3
@@ -168,7 +168,7 @@ Then visit http://localhost:8501
 ## Troubleshooting
 
 ### Local Development Issues
-- Ensure Python 3.8+ is installed
+- Ensure Python 3.8+ is installed (except 3.9.7)
 - Use the provided `./setup.sh` script for automated setup
 - Try manual installation if the script fails
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,25 +23,24 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-dependencies = [
-    "streamlit>=1.45.0",
-    "pandas>=2.0.0",
-    "numpy>=1.24.0",
-    "matplotlib>=3.7.0",
-    "Pillow>=10.0.0",
-    "pyarrow>=13.0.0",
-    "altair>=5.0.0",
-    "scikit-image>=0.21.0",
-    "scikit-learn>=1.3.0",
-    "scipy>=1.11.0",
-    "imageio>=2.31.0",
-    "requests>=2.31.0",
-    "streamlit-nested-layout>=0.1.4",
-    "streamlit-pdf-viewer>=0.0.23",
-    "opencv-python>=4.8.0",
-    "tifffile>=2023.7.0",
-    "streamlit-image-coordinates>=0.1.6"
-]
+[project.dependencies]
+streamlit = ">=1.45.0"
+pandas = ">=2.0.0"
+numpy = ">=1.24.0"
+matplotlib = ">=3.7.0"
+Pillow = ">=10.0.0"
+pyarrow = ">=13.0.0"
+altair = ">=5.0.0"
+"scikit-image" = ">=0.21.0"
+"scikit-learn" = ">=1.3.0"
+scipy = ">=1.11.0"
+imageio = ">=2.31.0"
+requests = ">=2.31.0"
+"streamlit-nested-layout>=0.1.4" = {python = ">=3.8,<3.9.7 || >3.9.7"}
+"streamlit-pdf-viewer" = ">=0.0.23"
+"opencv-python" = ">=4.8.0"
+tifffile = ">=2023.7.0"
+"streamlit-image-coordinates" = ">=0.1.6"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary
- convert `project.dependencies` table and restrict streamlit-nested-layout for Python versions except 3.9.7
- clarify in README that Python 3.9.7 is not supported

## Testing
- `python tests/run_tests.py fast` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68411e7ef6448327af2e9c34d67f992f

## Summary by Sourcery

Migrate project dependencies in pyproject.toml to table format and add an environment marker to exclude streamlit-nested-layout on Python 3.9.7, and update README to clarify that Python 3.9.7 is not supported

Enhancements:
- Convert dependencies in pyproject.toml to PEP 621 table syntax
- Restrict streamlit-nested-layout package from Python 3.9.7 using an environment marker

Documentation:
- Clarify in README that Python 3.9.7 is unsupported in version checks, runtime configuration, and troubleshooting sections