### PR TITLE
Fix pyproject dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,24 +23,25 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
 ]
-[project.dependencies]
-streamlit = ">=1.45.0"
-pandas = ">=2.0.0"
-numpy = ">=1.24.0"
-matplotlib = ">=3.7.0"
-Pillow = ">=10.0.0"
-pyarrow = ">=13.0.0"
-altair = ">=5.0.0"
-"scikit-image" = ">=0.21.0"
-"scikit-learn" = ">=1.3.0"
-scipy = ">=1.11.0"
-imageio = ">=2.31.0"
-requests = ">=2.31.0"
-"streamlit-nested-layout>=0.1.4" = {python = ">=3.8,<3.9.7 || >3.9.7"}
-"streamlit-pdf-viewer" = ">=0.0.23"
-"opencv-python" = ">=4.8.0"
-tifffile = ">=2023.7.0"
-"streamlit-image-coordinates" = ">=0.1.6"
+dependencies = [
+    "streamlit>=1.45.0",
+    "pandas>=2.0.0",
+    "numpy>=1.24.0",
+    "matplotlib>=3.7.0",
+    "Pillow>=10.0.0",
+    "pyarrow>=13.0.0",
+    "altair>=5.0.0",
+    "scikit-image>=0.21.0",
+    "scikit-learn>=1.3.0",
+    "scipy>=1.11.0",
+    "imageio>=2.31.0",
+    "requests>=2.31.0",
+    "streamlit-nested-layout>=0.1.4; python_version >= '3.8' and (python_version < '3.9.7' or python_version > '3.9.7')",
+    "streamlit-pdf-viewer>=0.0.23",
+    "opencv-python>=4.8.0",
+    "tifffile>=2023.7.0",
+    "streamlit-image-coordinates>=0.1.6",
+]
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary
- fix `pyproject.toml` to use an array for dependencies
- run the full test suite

## Testing
- `./setup.sh dev-setup`
- `./setup.sh test`


------
https://chatgpt.com/codex/tasks/task_e_684127f703008327a86025747790692f

## Summary by Sourcery

Use an array format for project dependencies in pyproject.toml to comply with PEP 621.

Bug Fixes:
- Fix invalid dependency syntax in pyproject.toml

Enhancements:
- Replace the [project.dependencies] table with a single 'dependencies' array in pyproject.toml
- Convert each dependency entry to a PEP 508 string in the dependencies array