### PR TITLE
Include modules package in Poetry build

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ streamlit run app.py
 ### Local Development
 - Production dependencies: `pip install -e .`
 - Development dependencies: `pip install -e ".[dev]"`
+- Building with `poetry build` produces a wheel containing both the
+  `multiphoton_guide` and `modules` packages.
 
 ### For Deployment Platforms
 Some platforms still require `requirements.txt`. Generate one if needed:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,8 @@ multiphoton-guide = "app:main"
 
 [tool.poetry]
 packages = [
-  { include = "multiphoton_guide" }
+  { include = "multiphoton_guide" },
+  { include = "modules" }
 ]
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
## Summary
- package `modules` alongside `multiphoton_guide` using Poetry
- document that the wheel now contains both packages

## Testing
- `poetry build`
- `python tests/run_tests.py fast`

------
https://chatgpt.com/codex/tasks/task_e_68413fc99df483279d0cf0ab0227345e

## Summary by Sourcery

Include the `modules` package in the Poetry packaging configuration and update documentation to reflect the combined wheel contents.

New Features:
- Include the `modules` package in the Poetry build alongside `multiphoton_guide`.

Documentation:
- Update README to note that the built wheel contains both `multiphoton_guide` and `modules` packages.