### PR TITLE
Fix testing_utils imports

### DIFF
--- a/modules/testing_utils.py
+++ b/modules/testing_utils.py
@@ -10,8 +10,8 @@ from typing import Any, Callable, Dict, List
 import numpy as np
 import pandas as pd
 
-from modules.constants import COLUMN_SCHEMAS, FILE_MAPPINGS
-from modules.shared_utils import create_default_dataframe, load_measurement_dataframe
+from modules.core.constants import COLUMN_SCHEMAS, FILE_MAPPINGS
+from modules.core.shared_utils import create_default_dataframe, load_measurement_dataframe
 
 
 class TestResult:


### PR DESCRIPTION
## Summary
- point `testing_utils` imports to `modules.core`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68413fe2a0ac8327bf056fd26fcdc679

## Summary by Sourcery

Bug Fixes:
- Point testing_utils imports for constants and shared_utils to modules.core