### PR TITLE
Switch to SQL-based data storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,28 @@ pip-compile pyproject.toml
 
 All dependencies are defined in `pyproject.toml` but can be exported to `requirements.txt` for deployment platforms that require it.
 
+## Database Setup
+
+Measurement data is stored in a SQL database. By default the app tries to use a
+`postgresql` connection defined in `streamlit` secrets. If that connection is
+not available, the URL from the `DATABASE_URL` environment variable (or the
+`database_url` entry in secrets) is used. For local testing you can rely on a
+SQLite database:
+
+```toml
+[postgresql]
+user = "myuser"
+password = "mypassword"
+host = "localhost"
+database = "multiphoton"
+
+# Or provide a full URL
+database_url = "sqlite:///data.db"
+```
+
+Set these credentials in `.streamlit/secrets.toml` or as environment variables
+so `get_connection()` can establish a connection.
+
 ### Docker Deployment
 
 For containerized deployment:

--- a/modules/core/data_utils.py
+++ b/modules/core/data_utils.py
@@ -9,18 +9,23 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-# Define data directory
+from .database_utils import (
+    load_dataframe_from_table,
+    save_dataframe_to_table,
+)
+
+# Define data directory (legacy compatibility for table name conversion)
 DATA_DIR = Path("data")
 
 
 def ensure_data_dir():
-    """Ensure the data directory exists."""
+    """Ensure the data directory exists (retained for backward compatibility)."""
     os.makedirs(DATA_DIR, exist_ok=True)
 
 
 def save_dataframe(df, filename):
     """
-    Save a dataframe to CSV.
+    Save a dataframe to a SQL table.
 
     Parameters:
     -----------
@@ -34,15 +39,13 @@ def save_dataframe(df, filename):
     str
         Path to the saved file
     """
-    ensure_data_dir()
-    file_path = DATA_DIR / filename
-    df.to_csv(file_path, index=False)
-    return file_path
+    save_dataframe_to_table(df, filename)
+    return filename
 
 
 def load_dataframe(filename, default_df=None):
     """
-    Load a dataframe from CSV or return a default if file doesn't exist.
+    Load a dataframe from a SQL table or return a default if it doesn't exist.
 
     Parameters:
     -----------
@@ -56,15 +59,12 @@ def load_dataframe(filename, default_df=None):
     pandas.DataFrame
         The loaded or default dataframe
     """
-    ensure_data_dir()
-    file_path = DATA_DIR / filename
-
-    if os.path.exists(file_path):
-        return pd.read_csv(file_path)
-    elif default_df is not None:
+    df = load_dataframe_from_table(filename)
+    if not df.empty:
+        return df
+    if default_df is not None:
         return default_df
-    else:
-        return pd.DataFrame()
+    return pd.DataFrame()
 
 
 def ensure_columns(df, required_columns, defaults=None):

--- a/modules/core/database_utils.py
+++ b/modules/core/database_utils.py
@@ -1,0 +1,42 @@
+import os
+from pathlib import Path
+
+import pandas as pd
+import streamlit as st
+from sqlalchemy import create_engine
+
+
+def get_connection(url: str | None = None):
+    """Return a SQLAlchemy engine using Streamlit secrets or environment vars."""
+    try:
+        conn = st.connection("postgresql")
+        if hasattr(conn, "engine"):
+            return conn.engine
+        # `st.connection` may return an object with .url attribute
+        return create_engine(conn.url)
+    except Exception:
+        db_url = url or st.secrets.get("database_url") or os.environ.get(
+            "DATABASE_URL", "sqlite:///data.db"
+        )
+        return create_engine(db_url)
+
+
+def _sanitize_table_name(name: str) -> str:
+    return Path(name).stem
+
+
+def save_dataframe_to_table(df: pd.DataFrame, table_name: str, if_exists: str = "replace") -> None:
+    """Save a DataFrame to the specified SQL table."""
+    engine = get_connection()
+    tbl = _sanitize_table_name(table_name)
+    df.to_sql(tbl, engine, if_exists=if_exists, index=False)
+
+
+def load_dataframe_from_table(table_name: str) -> pd.DataFrame:
+    """Load a DataFrame from a SQL table. Returns empty DataFrame if not found."""
+    engine = get_connection()
+    tbl = _sanitize_table_name(table_name)
+    try:
+        return pd.read_sql(f"SELECT * FROM {tbl}", engine)
+    except Exception:
+        return pd.DataFrame()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
     "streamlit>=1.45.0",
     "pandas>=2.0.0",
+    "SQLAlchemy>=2.0.0",
     "numpy>=1.24.0",
     "matplotlib>=3.7.0",
     "Pillow>=10.0.0",

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -184,13 +184,13 @@ class TestEndToEndWorkflow:
     """Test end-to-end workflows to ensure integration works."""
 
     def test_data_workflow(self):
-        """Test a complete data workflow."""
-        import tempfile
-        from pathlib import Path
-
+        """Test a complete data workflow using the DB utilities."""
+        
         import pandas as pd
+        from sqlalchemy import create_engine
 
         from modules.core.data_utils import load_dataframe, save_dataframe
+        from modules.core import database_utils
 
         # Create test data
         test_data = pd.DataFrame(
@@ -201,27 +201,23 @@ class TestEndToEndWorkflow:
             }
         )
 
-        # Use a temporary file for testing
-        with tempfile.NamedTemporaryFile(suffix=".csv", delete=False) as tmp:
-            try:
-                # Save data
-                save_dataframe(test_data, tmp.name)
+        engine = create_engine("sqlite:///:memory:")
+        monkeypatch = pytest.MonkeyPatch()
+        monkeypatch.setattr(database_utils, "get_connection", lambda url=None: engine)
 
-                # Load data back
-                loaded_data = load_dataframe(tmp.name)
+        table_name = "workflow_table"
 
-                # Verify data integrity
-                assert len(loaded_data) == len(
-                    test_data
-                ), "Loaded data should have same length"
-                assert list(loaded_data.columns) == list(
-                    test_data.columns
-                ), "Columns should match"
+        # Save data
+        save_dataframe(test_data, table_name)
 
-            finally:
-                # Clean up
-                if Path(tmp.name).exists():
-                    Path(tmp.name).unlink()
+        # Load data back
+        loaded_data = load_dataframe(table_name)
+
+        # Verify data integrity
+        assert len(loaded_data) == len(test_data), "Loaded data should have same length"
+        assert list(loaded_data.columns) == list(test_data.columns), "Columns should match"
+        
+        monkeypatch.undo()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add `database_utils` for database connectivity
- use DB helpers in `data_utils`
- update tests for SQL storage
- mention new database setup in README
- include SQLAlchemy dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684143981074832792f90e7cbb56b59e