### PR TITLE
Support Google Sheets backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,38 @@ pip-compile pyproject.toml
 
 All dependencies are defined in `pyproject.toml` but can be exported to `requirements.txt` for deployment platforms that require it.
 
+## Database Setup
+
+Measurement data can be stored either in a SQL database **or** in a public
+Google Sheet.  If a `[connections.gsheets]` section exists in
+`.streamlit/secrets.toml` the application will read and write data to that
+spreadsheet (see `docs/public_google_sheets.md`).  Otherwise the app falls back
+to a SQL database.  By default it tries to use a `postgresql` connection defined
+in Streamlit secrets.  If that connection is not available, the URL from the
+`DATABASE_URL` environment variable (or the `database_url` entry in secrets) is
+used.  For local testing you can rely on a SQLite database:
+
+```toml
+[postgresql]
+user = "myuser"
+password = "mypassword"
+host = "localhost"
+database = "multiphoton"
+
+# Or provide a full URL
+database_url = "sqlite:///data.db"
+```
+
+To use a public Google Sheet instead of SQL, configure secrets like this:
+
+```toml
+[connections.gsheets]
+spreadsheet = "https://docs.google.com/spreadsheets/d/YOUR_SHEET_ID/edit"
+```
+
+Set these credentials in `.streamlit/secrets.toml` or as environment variables
+so `get_connection()` can establish a connection.
+
 ### Docker Deployment
 
 For containerized deployment:

--- a/docs/public_google_sheets.md
+++ b/docs/public_google_sheets.md
@@ -1,0 +1,84 @@
+# Using a Public Google Sheet with Streamlit
+
+This guide walks through connecting your Streamlit application to a public Google Sheet using `st.connection` and the `streamlit-gsheets-connection` package. It summarizes the steps from [Streamlit's tutorial](https://docs.streamlit.io/develop/tutorials/databases/public-gsheet).
+
+## Prerequisites
+
+- **Streamlit** version `1.28` or newer
+- **Python package** `st-gsheets-connection` installed
+
+Install the package with:
+
+```bash
+pip install st-gsheets-connection
+```
+
+## 1. Create a Google Sheet and enable link sharing
+
+1. Create a spreadsheet in Google Sheets (or open an existing one).
+2. Share it using **Anyone with the link** set to **Viewer**.
+3. Copy the share URL.
+
+## 2. Store the Sheet URL in Streamlit secrets
+
+Create (or update) `.streamlit/secrets.toml` in your project and add the link:
+
+```toml
+# .streamlit/secrets.toml
+[connections.gsheets]
+spreadsheet = "https://docs.google.com/spreadsheets/d/XXXXXX/edit#gid=0"
+```
+
+## 3. Read data from the Sheet in your app
+
+Use `st.connection` to create a connection and call `.read()` to retrieve the data or
+`conn.update()` to write data back:
+
+```python
+import streamlit as st
+from streamlit_gsheets import GSheetsConnection
+
+# Create a connection object
+conn = st.connection("gsheets", type=GSheetsConnection)
+
+# Read a worksheet by name
+df = conn.read(worksheet="Sheet1")
+
+# Display the results
+for row in df.itertuples():
+    st.write(f"{row.name} has a :{row.pet}:")
+
+## 4. Write data back to the Sheet
+
+```python
+new_df = pd.DataFrame({"name": ["Lucia"], "pet": ["dog"]})
+conn.update(worksheet="Sheet1", data=new_df)
+```
+
+## Optional: customize caching and range
+
+`st.connection` caches `.read()` by default. You can adjust parameters such as the worksheet, columns, number of rows, and cache duration:
+
+```python
+df = conn.read(
+    worksheet="Sheet1",
+    ttl="10m",    # cache results for at most 10 minutes
+    usecols=[0, 1],
+    nrows=3,
+)
+```
+
+Set `ttl=0` to disable caching entirely if needed.
+
+## 5. Deploying on Streamlit Community Cloud
+
+When deploying to Streamlit Community Cloud:
+
+1. Include `st-gsheets-connection` in your `requirements.txt`.
+2. Add the same `[connections.gsheets]` section in your app's Secrets configuration on Cloud.
+
+Your app can then read from the public Google Sheet in the same way as locally.
+
+---
+
+Following these steps lets you pull data from a public Google Sheet without storing credentials in your code. `st.connection` handles secrets, caching, and retries for you.

--- a/modules/core/data_utils.py
+++ b/modules/core/data_utils.py
@@ -9,18 +9,23 @@ from pathlib import Path
 import numpy as np
 import pandas as pd
 
-# Define data directory
+from .database_utils import (
+    load_dataframe_from_table,
+    save_dataframe_to_table,
+)
+
+# Define data directory (legacy compatibility for table name conversion)
 DATA_DIR = Path("data")
 
 
 def ensure_data_dir():
-    """Ensure the data directory exists."""
+    """Ensure the data directory exists (retained for backward compatibility)."""
     os.makedirs(DATA_DIR, exist_ok=True)
 
 
 def save_dataframe(df, filename):
     """
-    Save a dataframe to CSV.
+    Save a dataframe to a SQL table.
 
     Parameters:
     -----------
@@ -34,15 +39,13 @@ def save_dataframe(df, filename):
     str
         Path to the saved file
     """
-    ensure_data_dir()
-    file_path = DATA_DIR / filename
-    df.to_csv(file_path, index=False)
-    return file_path
+    save_dataframe_to_table(df, filename)
+    return filename
 
 
 def load_dataframe(filename, default_df=None):
     """
-    Load a dataframe from CSV or return a default if file doesn't exist.
+    Load a dataframe from a SQL table or return a default if it doesn't exist.
 
     Parameters:
     -----------
@@ -56,15 +59,12 @@ def load_dataframe(filename, default_df=None):
     pandas.DataFrame
         The loaded or default dataframe
     """
-    ensure_data_dir()
-    file_path = DATA_DIR / filename
-
-    if os.path.exists(file_path):
-        return pd.read_csv(file_path)
-    elif default_df is not None:
+    df = load_dataframe_from_table(filename)
+    if not df.empty:
+        return df
+    if default_df is not None:
         return default_df
-    else:
-        return pd.DataFrame()
+    return pd.DataFrame()
 
 
 def ensure_columns(df, required_columns, defaults=None):

--- a/modules/core/database_utils.py
+++ b/modules/core/database_utils.py
@@ -1,0 +1,75 @@
+import os
+from pathlib import Path
+from typing import Optional
+
+import pandas as pd
+import streamlit as st
+
+try:
+    from sqlalchemy import create_engine
+except ImportError:  # pragma: no cover - SQLAlchemy optional when using gsheets
+    create_engine = None  # type: ignore
+
+try:
+    from streamlit_gsheets import GSheetsConnection
+except Exception:  # pragma: no cover - gsheets optional
+    GSheetsConnection = None  # type: ignore
+
+
+def get_gsheets_connection() -> Optional["GSheetsConnection"]:
+    """Return a GSheetsConnection if configured via Streamlit secrets."""
+    if GSheetsConnection is None:
+        return None
+    try:
+        return st.connection("gsheets", type=GSheetsConnection)
+    except Exception:
+        return None
+
+
+def get_connection(url: str | None = None):
+    """Return a SQLAlchemy engine using Streamlit secrets or environment vars."""
+    if create_engine is None:
+        raise RuntimeError(
+            "SQLAlchemy is required for SQL database access but is not installed."
+        )
+    try:
+        conn = st.connection("postgresql")
+        if hasattr(conn, "engine"):
+            return conn.engine
+        return create_engine(conn.url)
+    except Exception:
+        db_url = url or st.secrets.get("database_url") or os.environ.get(
+            "DATABASE_URL", "sqlite:///data.db"
+        )
+        return create_engine(db_url)
+
+
+def _sanitize_table_name(name: str) -> str:
+    return Path(name).stem
+
+
+def save_dataframe_to_table(df: pd.DataFrame, table_name: str, if_exists: str = "replace") -> None:
+    """Save a DataFrame to the specified table (SQL or Google Sheet)."""
+    gs_conn = get_gsheets_connection()
+    tbl = _sanitize_table_name(table_name)
+    if gs_conn is not None:
+        gs_conn.update(worksheet=tbl, data=df)
+    else:
+        engine = get_connection()
+        df.to_sql(tbl, engine, if_exists=if_exists, index=False)
+
+
+def load_dataframe_from_table(table_name: str) -> pd.DataFrame:
+    """Load a DataFrame from a SQL table or Google Sheet."""
+    tbl = _sanitize_table_name(table_name)
+    gs_conn = get_gsheets_connection()
+    if gs_conn is not None:
+        try:
+            return gs_conn.read(worksheet=tbl)
+        except Exception:
+            return pd.DataFrame()
+    engine = get_connection()
+    try:
+        return pd.read_sql(f"SELECT * FROM {tbl}", engine)
+    except Exception:
+        return pd.DataFrame()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 dependencies = [
     "streamlit>=1.45.0",
     "pandas>=2.0.0",
+    "SQLAlchemy>=2.0.0",
     "numpy>=1.24.0",
     "matplotlib>=3.7.0",
     "Pillow>=10.0.0",
@@ -40,6 +41,7 @@ dependencies = [
     "opencv-python>=4.8.0",
     "tifffile>=2023.7.0",
     "streamlit-image-coordinates>=0.1.6",
+    "st-gsheets-connection>=0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/test_data_utils.py
+++ b/tests/test_data_utils.py
@@ -14,6 +14,9 @@ import pytest
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
 # Import data utilities for testing
+from sqlalchemy import create_engine
+
+from modules.core import database_utils
 from modules.core.data_utils import (
     calculate_statistics,
     ensure_columns,
@@ -45,6 +48,15 @@ def test_data_dir(tmp_path):
     data_dir = tmp_path / "data"
     data_dir.mkdir()
     return data_dir
+
+
+@pytest.fixture
+def in_memory_db(monkeypatch):
+    """Provide an in-memory SQLite engine and patch database connection."""
+    engine = create_engine("sqlite:///:memory:")
+    monkeypatch.setattr(database_utils, "get_connection", lambda url=None: engine)
+    monkeypatch.setattr(database_utils, "get_gsheets_connection", lambda: None)
+    return engine
 
 
 # Test data utilities
@@ -189,27 +201,26 @@ def test_safe_numeric_conversion_edge_cases(test_dataframe):
 
 # Test file operations
 @pytest.mark.unit
-def test_save_and_load_dataframe(test_dataframe, test_data_dir):
-    """Test that save_dataframe and load_dataframe work correctly."""
-    file_path = test_data_dir / "test.csv"
+def test_save_and_load_dataframe(test_dataframe, in_memory_db):
+    """Test saving and loading a dataframe via the database helpers."""
+    table_name = "test_table"
 
     # Save the dataframe
-    save_dataframe(test_dataframe, file_path)
+    save_dataframe(test_dataframe, table_name)
 
     # Load the dataframe
-    loaded_df = load_dataframe(file_path)
+    loaded_df = load_dataframe(table_name)
 
     # Check that the loaded dataframe matches the original
     pd.testing.assert_frame_equal(test_dataframe, loaded_df)
 
 
 @pytest.mark.unit
-def test_load_dataframe_with_default(test_data_dir):
-    """Test that load_dataframe returns the default dataframe when file doesn't exist."""
-    file_path = test_data_dir / "nonexistent.csv"
+def test_load_dataframe_with_default(in_memory_db):
+    """Test that load_dataframe returns the default dataframe when table doesn't exist."""
     default_df = pd.DataFrame({"A": [1, 2, 3]})
 
-    loaded_df = load_dataframe(file_path, default_df)
+    loaded_df = load_dataframe("missing_table", default_df)
 
     # Check that the loaded dataframe matches the default
     pd.testing.assert_frame_equal(default_df, loaded_df)


### PR DESCRIPTION
## Summary
- add st-gsheets-connection as dependency
- update README with Google Sheets instructions
- document reading and writing worksheets in docs/public_google_sheets.md
- extend database_utils to read/write from Google Sheets when configured
- adjust tests for new helper functions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684143981074832792f90e7cbb56b59e

## Summary by Sourcery

Implement a Google Sheets backend alongside SQL support by introducing a database_utils abstraction, refactor data_utils to use it, update tests, documentation, and dependencies accordingly.

New Features:
- Add Google Sheets backend for storing and retrieving data via Streamlit connections
- Introduce a database_utils module to abstract DataFrame persistence to SQL databases or Google Sheets

Enhancements:
- Refactor data_utils to delegate persistence to database_utils and remove CSV file handling
- Update tests to use an in-memory database and monkeypatch connections instead of temporary files
- Extend README with configuration instructions for SQL and Google Sheets backends

Build:
- Add SQLAlchemy and st-gsheets-connection dependencies to pyproject.toml

Documentation:
- Add a public_google_sheets.md guide detailing how to connect and use a public Google Sheet with Streamlit

Tests:
- Add an in-memory database fixture and adjust unit and integration tests for the new database_utils workflow