### PR TITLE
Remove SQL storage and rely on Google Sheets

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,37 +148,19 @@ All dependencies are defined in `pyproject.toml` but can be exported to `require
 
 ## Database Setup
 
-Measurement data can be stored either in a SQL database **or** in a public
-Google Sheet.  If a `[connections.gsheets]` section exists in
-`.streamlit/secrets.toml` the application will read and write data to that
-spreadsheet (see `docs/public_google_sheets.md`).  Otherwise the app falls back
-to a SQL database.  By default it tries to use a `postgresql` connection defined
-in Streamlit secrets.  If that connection is not available, the URL from the
-`DATABASE_URL` environment variable (or the `database_url` entry in secrets) is
-used.  For local testing you can rely on a SQLite database:
-
-
-```toml
-[postgresql]
-user = "myuser"
-password = "mypassword"
-host = "localhost"
-database = "multiphoton"
-
-# Or provide a full URL
-database_url = "sqlite:///data.db"
-```
-
-To use a public Google Sheet instead of SQL, configure secrets like this:
+Measurement data is stored in a public Google Sheet. Configure a
+`[connections.gsheets]` section in `.streamlit/secrets.toml` as shown below and
+the application will read and write data to that spreadsheet (see
+`docs/public_google_sheets.md`). If the connection is not configured the
+application will raise an error.
 
 ```toml
 [connections.gsheets]
 spreadsheet = "https://docs.google.com/spreadsheets/d/YOUR_SHEET_ID/edit"
 ```
 
-
-Set these credentials in `.streamlit/secrets.toml` or as environment variables
-so `get_connection()` can establish a connection.
+Place these credentials in `.streamlit/secrets.toml` so the application can
+establish the Google Sheets connection.
 
 ### Docker Deployment
 

--- a/modules/core/data_utils.py
+++ b/modules/core/data_utils.py
@@ -25,7 +25,7 @@ def ensure_data_dir():
 
 def save_dataframe(df, filename):
     """
-    Save a dataframe to a SQL table.
+    Save a dataframe to a Google Sheet table.
 
     Parameters:
     -----------
@@ -45,7 +45,7 @@ def save_dataframe(df, filename):
 
 def load_dataframe(filename, default_df=None):
     """
-    Load a dataframe from a SQL table or return a default if it doesn't exist.
+    Load a dataframe from a Google Sheet or return a default if it doesn't exist.
 
     Parameters:
     -----------

--- a/modules/core/database_utils.py
+++ b/modules/core/database_utils.py
@@ -1,14 +1,7 @@
-import os
 from pathlib import Path
-from typing import Optional
 
 import pandas as pd
 import streamlit as st
-
-try:
-    from sqlalchemy import create_engine
-except ImportError:  # pragma: no cover - SQLAlchemy optional when using gsheets
-    create_engine = None  # type: ignore
 
 try:
     from streamlit_gsheets import GSheetsConnection
@@ -16,62 +9,38 @@ except Exception:  # pragma: no cover - gsheets optional
     GSheetsConnection = None  # type: ignore
 
 
-def get_gsheets_connection() -> Optional["GSheetsConnection"]:
-    """Return a GSheetsConnection if configured via Streamlit secrets."""
+def get_gsheets_connection() -> "GSheetsConnection":
+    """Return a configured GSheetsConnection or raise an error."""
     if GSheetsConnection is None:
-        return None
+        raise RuntimeError(
+            "streamlit-gsheets is required for Google Sheets storage but is not installed"
+        )
     try:
         return st.connection("gsheets", type=GSheetsConnection)
-    except Exception:
-        return None
+    except Exception as exc:  # pragma: no cover - configuration errors
+        raise RuntimeError("Google Sheets connection 'gsheets' is not configured") from exc
 
 
-def get_connection(url: str | None = None):
-    """Return a SQLAlchemy engine using Streamlit secrets or environment vars."""
-    if create_engine is None:
-        raise RuntimeError(
-            "SQLAlchemy is required for SQL database access but is not installed."
-        )
-    try:
-        conn = st.connection("postgresql")
-        if hasattr(conn, "engine"):
-            return conn.engine
-
-        return create_engine(conn.url)
-    except Exception:
-        db_url = url or st.secrets.get("database_url") or os.environ.get(
-            "DATABASE_URL", "sqlite:///data.db"
-        )
-        return create_engine(db_url)
 
 
 def _sanitize_table_name(name: str) -> str:
     return Path(name).stem
 
 
-def save_dataframe_to_table(df: pd.DataFrame, table_name: str, if_exists: str = "replace") -> None:
-    """Save a DataFrame to the specified table (SQL or Google Sheet)."""
-    gs_conn = get_gsheets_connection()
+def save_dataframe_to_table(
+    df: pd.DataFrame, table_name: str, if_exists: str = "replace"
+) -> None:
+    """Save a DataFrame to the specified Google Sheet."""
+    conn = get_gsheets_connection()
     tbl = _sanitize_table_name(table_name)
-    if gs_conn is not None:
-        gs_conn.update(worksheet=tbl, data=df)
-    else:
-        engine = get_connection()
-        df.to_sql(tbl, engine, if_exists=if_exists, index=False)
+    conn.update(worksheet=tbl, data=df)
 
 
 def load_dataframe_from_table(table_name: str) -> pd.DataFrame:
-    """Load a DataFrame from a SQL table or Google Sheet."""
+    """Load a DataFrame from a Google Sheet."""
     tbl = _sanitize_table_name(table_name)
-    gs_conn = get_gsheets_connection()
-    if gs_conn is not None:
-        try:
-            return gs_conn.read(worksheet=tbl)
-        except Exception:
-            return pd.DataFrame()
-    engine = get_connection()
-
+    conn = get_gsheets_connection()
     try:
-        return pd.read_sql(f"SELECT * FROM {tbl}", engine)
+        return conn.read(worksheet=tbl)
     except Exception:
         return pd.DataFrame()

--- a/packages.txt
+++ b/packages.txt
@@ -1,1 +1,6 @@
 libgl1
+libglib2.0-0
+poppler-utils
+libgtk2.0-0
+libx11-xcb1
+libnss3


### PR DESCRIPTION
## Summary
- drop SQLAlchemy connection helpers and always use Google Sheets
- update README to describe only Google Sheets storage
- adjust tests to mock Google Sheets connection
- add required system dependencies for heavy packages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684331c512b4832791a3cbbb3c473e99