### PR TITLE
Improve gsheets connection info and error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,18 @@ spreadsheet = "https://docs.google.com/spreadsheets/d/YOUR_SHEET_ID/edit"
 Place these credentials in `.streamlit/secrets.toml` so the application can
 establish the Google Sheets connection.
 
+The app uses the
+[`st-gsheets-connection`](https://pypi.org/project/st-gsheets-connection/)
+package. Create the connection in your code with
+
+```python
+from streamlit_gsheets import GSheetsConnection
+conn = st.connection("gsheets", type=GSheetsConnection)
+df = conn.read(worksheet="Sheet1")
+```
+
+If the connection fails, the app will display an error in the sidebar.
+
 ### Docker Deployment
 
 For containerized deployment:

--- a/modules/core/database_utils.py
+++ b/modules/core/database_utils.py
@@ -39,8 +39,10 @@ def save_dataframe_to_table(
 def load_dataframe_from_table(table_name: str) -> pd.DataFrame:
     """Load a DataFrame from a Google Sheet."""
     tbl = _sanitize_table_name(table_name)
-    conn = get_gsheets_connection()
     try:
+        conn = get_gsheets_connection()
         return conn.read(worksheet=tbl)
-    except Exception:
+    except Exception as exc:
+        # Surface the error to the UI for easier debugging
+        st.error(f"Failed to load data from worksheet '{tbl}': {exc}")
         return pd.DataFrame()

--- a/modules/measurements/laser_power.py
+++ b/modules/measurements/laser_power.py
@@ -66,13 +66,20 @@ def render_laser_power_tab(use_sidebar_values=False):
             # Load existing data
             laser_power_df = load_dataframe(LASER_POWER_FILE, pd.DataFrame())
 
-            if not laser_power_df.empty:
+            if laser_power_df.empty:
+                st.info(
+                    "No measurements found. Check your Google Sheets connection or "
+                    "add data to the sheet."
+                )
+            else:
                 # Filter to current study
                 filtered_df = filter_dataframe(
                     laser_power_df, {"Study Name": st.session_state.study_name}
                 )
 
-                if not filtered_df.empty:
+                if filtered_df.empty:
+                    st.info("No measurements found for the current study.")
+                else:
                     # Sort by date (newest first) and select only the most recent measurements
                     filtered_df = filtered_df.sort_values("Date", ascending=False).head(
                         5


### PR DESCRIPTION
## Summary
- show helpful error when Google Sheets read fails
- display message in laser power tab when data or study matches are missing
- document gsheets connection snippet in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684709cc1e0c8327a83f5f057959bc89

## Summary by Sourcery

Document the Google Sheets connection setup and improve error handling by surfacing errors in the UI and showing informative messages when data is missing.

Enhancements:
- Display info messages in the laser power tab when no measurements or no current-study data are found.
- Catch exceptions in data loading and show detailed error messages in the UI via `st.error`.

Documentation:
- Add `st-gsheets-connection` usage example and error handling note to README.