### PR TITLE
Implement measurement data saving

### DIFF
--- a/modules/ui/templates.py
+++ b/modules/ui/templates.py
@@ -7,6 +7,10 @@ from abc import ABC, abstractmethod
 from typing import Any, Callable, Dict, List
 
 import streamlit as st
+import pandas as pd
+
+from modules.core.constants import FILE_MAPPINGS
+from modules.core.data_utils import save_dataframe
 
 from modules.core.shared_utils import (
     add_to_rig_log,
@@ -236,7 +240,7 @@ def _save_measurement_data(df_type: str, form_data: Dict[str, Any]) -> bool:
 
     def save_operation():
         # Load existing data
-        load_measurement_dataframe(df_type)
+        df = load_measurement_dataframe(df_type)
 
         # Create new entry
         new_entry = {**form_data}
@@ -245,8 +249,9 @@ def _save_measurement_data(df_type: str, form_data: Dict[str, Any]) -> bool:
         new_entry["Researcher"] = st.session_state.get("researcher", "")
 
         # Append and save
-        # This would use the shared save functionality
-        # Implementation details would depend on existing data_utils functions
+        new_row = pd.DataFrame([new_entry])
+        updated_df = pd.concat([df, new_row], ignore_index=True)
+        save_dataframe(updated_df, FILE_MAPPINGS[df_type])
 
         return True
 

--- a/tests/test_ui_templates.py
+++ b/tests/test_ui_templates.py
@@ -1,0 +1,58 @@
+import os
+import sys
+from unittest.mock import patch
+
+import pandas as pd
+import pytest
+
+from modules.core import database_utils
+from modules.core.data_utils import load_dataframe, save_dataframe
+from modules.core.constants import FILE_MAPPINGS
+from modules.ui.templates import _save_measurement_data
+
+
+class DummyGSheets:
+    def __init__(self):
+        self.tables = {}
+
+    def update(self, worksheet: str, data):
+        self.tables[worksheet] = data.copy()
+
+    def read(self, worksheet: str):
+        return self.tables.get(worksheet, pd.DataFrame())
+
+
+@pytest.fixture
+def mock_gsheets(monkeypatch):
+    conn = DummyGSheets()
+    monkeypatch.setattr(database_utils, "get_gsheets_connection", lambda: conn)
+    return conn
+
+
+@pytest.mark.unit
+def test_save_measurement_data_appends(mock_gsheets):
+    initial = pd.DataFrame({
+        "Study Name": ["Existing"],
+        "Date": ["2024-01-01"],
+        "Researcher": ["Alice"],
+    })
+    save_dataframe(initial, FILE_MAPPINGS["laser_power"])
+
+    form_data = {"Notes": "test note"}
+    with patch.object(
+        sys.modules["streamlit"], "session_state", {
+            "current_timestamp": "2024-01-02",
+            "study_name": "New Study",
+            "researcher": "Bob",
+        },
+    ):
+        result = _save_measurement_data("laser_power", form_data)
+
+    assert result is True
+
+    df = load_dataframe(FILE_MAPPINGS["laser_power"])
+    assert len(df) == 2
+    assert df.iloc[-1]["Study Name"] == "New Study"
+    assert df.iloc[-1]["Researcher"] == "Bob"
+    assert df.iloc[-1]["Date"] == "2024-01-02"
+    assert df.iloc[-1]["Notes"] == "test note"


### PR DESCRIPTION
## Summary
- implement `_save_measurement_data` to append form data and persist
- include mapping/df saving via `FILE_MAPPINGS`
- add unit test for new helper

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68475ca7daf483279d949bcfa49a191f