### PR TITLE
Switch to gspread for Google Sheets integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,14 +162,17 @@ spreadsheet = "https://docs.google.com/spreadsheets/d/YOUR_SHEET_ID/edit"
 Place these credentials in `.streamlit/secrets.toml` so the application can
 establish the Google Sheets connection.
 
-The app uses the
-[`st-gsheets-connection`](https://pypi.org/project/st-gsheets-connection/)
-package. Create the connection in your code with
+The app now uses [`gspread`](https://pypi.org/project/gspread/) directly. A
+simple usage example is:
 
 ```python
-from streamlit_gsheets import GSheetsConnection
-conn = st.connection("gsheets", type=GSheetsConnection)
-df = conn.read(worksheet="Sheet1")
+import gspread
+from gspread_dataframe import get_as_dataframe
+
+creds = st.secrets["connections"]["gsheets"]
+client = gspread.service_account_from_dict(creds)
+sheet = client.open_by_url(creds["spreadsheet"])
+df = get_as_dataframe(sheet.worksheet("Sheet1"))
 ```
 
 If the connection fails, the app will display an error in the sidebar.

--- a/poetry.lock
+++ b/poetry.lock
@@ -3327,32 +3327,6 @@ files = [
     {file = "sqlparse-0.5.3.tar.gz", hash = "sha256:09f67787f56a0b16ecdbde1bfc7f5d9c3371ca683cfeaa8e6ff60b4807ec9272"},
 ]
 
-[package.extras]
-dev = ["build", "hatch"]
-doc = ["sphinx"]
-
-[[package]]
-name = "st-gsheets-connection"
-version = "0.1.0"
-description = "Streamlit Connection for Google Sheets."
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "st_gsheets_connection-0.1.0-py3-none-any.whl", hash = "sha256:4de86d74c17f02188e0d618b2591d9e57b59e1c6f125ed3eef74e19eac074fda"},
-    {file = "st_gsheets_connection-0.1.0.tar.gz", hash = "sha256:bba0306ce5bdacd70c1c65ad91d31d718709fc136d7709c1fa5b2113b709f958"},
-]
-
-[package.dependencies]
-duckdb = ">=0.8.1"
-gspread = ">=5.8.0,<6"
-gspread-dataframe = ">=3.3.0"
-gspread-formatting = ">=1.1.2"
-gspread-pandas = ">=3.2.2"
-sql-metadata = ">=2.7.0"
-streamlit = ">=1.32.0"
-validators = ">=0.22.0"
-
 [[package]]
 name = "stack-data"
 version = "0.6.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,8 @@ dependencies = [
     "opencv-python>=4.8.0",
     "tifffile>=2023.7.0",
     "streamlit-image-coordinates>=0.1.6",
-    "st-gsheets-connection>=0.1.0",
+    "gspread>=5.8.0",
+    "gspread-dataframe>=4.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- swap out `st-gsheets-connection` for `gspread`
- update example usage in README
- document how to use gspread in the Google Sheets guide
- rewrite database utilities to use gspread
- drop st-gsheets-connection from lock file

## Testing
- `pytest -c /dev/null tests/test_data_utils.py -v`

------
https://chatgpt.com/codex/tasks/task_e_684761860c0c8327a096a977ffde5f01

## Summary by Sourcery

Switch Google Sheets integration from `st-gsheets-connection` to `gspread` by rewriting utilities, updating documentation, and adjusting dependencies accordingly.

Enhancements:
- Replace the old `streamlit-gsheets-connection` implementation in `database_utils` with a `GSpreadWrapper` using `gspread`.
- Revise the public Google Sheets guide and `README.md` examples to demonstrate direct `gspread` usage.
- Remove `st-gsheets-connection` from the lock file and update `pyproject.toml` to depend on `gspread` and `gspread-dataframe`.